### PR TITLE
remove dependabot setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: chore
-      include: scope


### PR DESCRIPTION
Dependabot setup breaks in actions, we will be moving to another dependency management system. 